### PR TITLE
Feat: Enforce App Photos/Descriptions and Improve Install Feedback

### DIFF
--- a/dockyard_app/app/routes.py
+++ b/dockyard_app/app/routes.py
@@ -15,13 +15,17 @@ def index():
         for t in templates_data:
             template_type = t.get('type')
             title = t.get('title')
-            if title and (template_type == 1 or template_type == 2 or template_type == '1' or template_type == '2'): # Accept string types too for display
+            logo = t.get('logo')
+            description = t.get('description')
+
+            # Only include templates that have a title, logo, description, and a supported type (1 or 2)
+            if title and logo and description and (template_type in [1, 2, '1', '2']):
                 processed_templates.append({
-                    'id': title.replace(' ', '_').lower(), # Simple ID from title
+                    'id': title.replace(' ', '_').lower(),  # Simple ID from title
                     'title': title,
-                    'description': t.get('description', 'No description available.'),
-                    'logo': t.get('logo', ''),
-                    'type': template_type, # Store original type for display/filtering
+                    'description': description,
+                    'logo': logo,
+                    'type': template_type,  # Store original type for display/filtering
                 })
     app.logger.info(f"Displaying {len(processed_templates)} templates from cache.")
     return render_template("index.html", title="DockYard - Available Apps", templates=processed_templates)

--- a/dockyard_app/templates/index.html
+++ b/dockyard_app/templates/index.html
@@ -70,6 +70,7 @@
 
                 showMessage(\`Starting installation for \${templateTitle}...\`, 'info');
                 button.disabled = true;
+                button.textContent = 'Installing...';
 
                 fetch('/install_app', {
                     method: 'POST',
@@ -92,6 +93,7 @@
                 })
                 .finally(() => {
                     button.disabled = false;
+                    button.textContent = 'Install';
                 });
             });
         });


### PR DESCRIPTION
This commit introduces two main improvements to the DockYard application:

1.  The application now filters the list of templates to only display those that include a title, a logo, and a description. This ensures a cleaner and more consistent user experience, as requested.

2.  The user feedback during application installation has been enhanced. The "Install" button now displays "Installing..." and is disabled while the installation is in progress. The button text reverts to "Install" after the operation completes.

The requested search functionality was attempted but ultimately reverted due to persistent, unresolvable technical issues within the development environment that prevented its successful implementation and verification.